### PR TITLE
Add "mpc_checks_cleaner" tool to the project

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [ "ls_dcm"]
+members = [ "ls_dcm", "mpc_checks_cleaner"]
 resolver = "2"
 
 [workspace.package]
@@ -14,7 +14,7 @@ anyhow = "1"
 quick-xml = "0.31"
 base64 = "0.22"
 ndarray = "0.15.6"
-clap = { version = "4.5.3", features = ["derive"] }
+clap = { version = "4.5.4", features = ["derive"] }
 dicom-core = "0.6"
 dicom-object = "0.6"
 dicom-dictionary-std = "0.6"
@@ -25,6 +25,7 @@ ratatui = { version = "0.26.1", features = ["default"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 comfy-table = "7"
+chrono = "0.4"
 
 #[workspace.dev-dependencies]
 log = "0.4"

--- a/mpc_checks_cleaner/Cargo.toml
+++ b/mpc_checks_cleaner/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rad-tools-mpc-checks-cleaner"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[dependencies]
+clap.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+chrono.workspace = true
+
+[[bin]]
+name = "mpc_checks_cleaner"
+path = "src/main.rs"

--- a/mpc_checks_cleaner/README.md
+++ b/mpc_checks_cleaner/README.md
@@ -1,0 +1,48 @@
+# MPC checks cleaner
+
+## Description
+
+An application that cleans MPC directories created by Varian TrueBeam or Ethos systems on the VA_TRANSFER share. Old MPC Checks are removed if they are older than the number of specified days. The application also has a dry-run option that prints which files it would delete without doing so.
+
+## Build
+
+```shell
+cargo build --release
+```
+
+## Usage
+
+```shell
+mpc_checks_cleaner.exe --help
+
+A command line interface (CLI) application to clean the MPC checks in the VA_TRANSFER share.
+
+The application removes old MPC checks from the VA_TRANSFER share. The application doesn't remove the Result.csv as it is small and can be usefull for external analysis. MPC checks are kept for a number of days before they are removed. Default value is 365 days.
+
+
+Usage: mpc_checks_cleaner.exe [OPTIONS] --dir <DIR>
+
+Options:
+  -d, --dir <DIR>
+          VA_TRANSFER share path
+
+  -k, --keep <KEEP>
+          Number of days the MPC checks are kept. Checks that are older, will be removed
+
+          [default: 365]
+
+      --dry-run
+          Enable logging at DEBUG level
+
+      --debug
+          Enable logging at DEBUG level
+
+      --trace
+          Enable logging at TRACE level
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+```

--- a/mpc_checks_cleaner/src/main.rs
+++ b/mpc_checks_cleaner/src/main.rs
@@ -1,0 +1,265 @@
+use std::path::Path;
+
+use chrono::{Local, NaiveDate, NaiveDateTime, NaiveTime};
+use clap::Parser;
+use tracing::{info, Level, trace};
+
+const TDS: &str = "TDS";
+const MPC_CHECKS: &str = "MPCChecks";
+
+/// A command line interface (CLI) application to clean the MPC checks in the VA_TRANSFER share.
+///
+/// The application removes old MPC checks from the VA_TRANSFER share. The application doesn't remove the Result.csv as it is small and can be usefull for external analysis. MPC checks are kept for a number of days before they are removed. Default value is 365 days.
+#[derive(Parser, Debug, Clone)]
+#[command(author, version, about, long_about = "
+A command line interface (CLI) application to clean the MPC checks in the VA_TRANSFER share.
+
+The application removes old MPC checks from the VA_TRANSFER share. The application doesn't remove the Result.csv as it is small and can be usefull for external analysis. MPC checks are kept for a number of days before they are removed. Default value is 365 days.
+")]
+struct Cli {
+    /// VA_TRANSFER share path
+    #[arg(short, long, value_name = "DIR")]
+    dir: String,
+    /// Number of days the MPC checks are kept. Checks that are older, will be removed.
+    #[arg(short, long, default_value_t = 365)]
+    keep: i64,
+    /// Enable logging at DEBUG level.
+    #[arg(long, default_value_t = false)]
+    dry_run: bool,
+    /// Enable logging at DEBUG level.
+    #[arg(long, default_value_t = false)]
+    debug: bool,
+    /// Enable logging at TRACE level.
+    #[arg(long, default_value_t = false)]
+    trace: bool,
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let level = if cli.trace {
+        Level::TRACE
+    } else if cli.debug {
+        Level::DEBUG
+    } else {
+        Level::WARN
+    };
+    tracing_subscriber::fmt()
+        .with_thread_ids(true)
+        .with_target(true)
+        .with_max_level(level)
+        .init();
+
+    if cli.dry_run {
+        println!("{}", text_box("DRY RUN (no data will be removed)"))
+    }
+
+    trace!("Commandline arguments: {:#?}", &cli);
+
+    let va_transfer_path = Path::new(&cli.dir);
+    if !va_transfer_path.exists() {
+        panic!("VA_TRANSFER share path does not exist.");
+    }
+    if !va_transfer_path.is_dir() {
+        panic!("VA_TRANSFER share path is not a directory.");
+    }
+
+    let tds_path = Path::join(va_transfer_path, TDS);
+    if !tds_path.exists() {
+        panic!("{:#?} share path does not exist.", tds_path);
+    }
+    if !tds_path.is_dir() {
+        panic!("{:#?} share path is not a directory.", tds_path);
+    }
+
+    match std::fs::read_dir(&tds_path) {
+        Ok(entries) => {
+            for entry in entries {
+                match entry {
+                    Ok(machine_id_entry) => {
+                        match machine_id_entry.metadata() {
+                            Ok(meta) => {
+                                if !meta.is_dir() {
+                                    panic!("Expecting all directory entries in {:#?} to be a directory [with a machine ID as a name]", tds_path);
+                                }
+                                let mpc_checks_path = Path::join(&machine_id_entry.path(), MPC_CHECKS);
+                                clean_mpc_checks_path(&mpc_checks_path, cli.keep, cli.dry_run);
+                            }
+                            Err(e) => {
+                                panic!("Unable to get machine directories in {:#?}.\n{:#?}", tds_path, e);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        panic!("Unable to get machine directories in {:#?}.\n{:#?}", tds_path, e);
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            panic!("Unable to get machine directories in {:#?}.\n{:#?}", tds_path, e);
+        }
+    }
+}
+
+fn newline() -> &'static str {
+    if std::env::consts::OS == "windows" {
+        "\r\n"
+    } else {
+        "\n"
+    }
+}
+
+fn text_box(s: &str) -> String {
+    let line = "+".repeat(s.len() + 4);
+    let empty_line = "|".to_string() + &" ".repeat(s.len() + 2) + "|";
+    let t = format!("| {} |", s);
+    format!("{}{}{}{}{}{}{}{}{}",
+            line, newline(), 
+            &empty_line, newline(), 
+            t, newline(), 
+            &empty_line, newline(), 
+            &line)
+}
+
+/// Cleans up the MPC checks path by removing checks that are older than a specified number of days.
+///
+/// # Arguments
+///
+/// * `path` - The path to the directory containing the MPC checks (e.g. <va_transfer share>/TDS/<machine_id>/MPCChecks).
+/// * `keep` - The number of days to keep the checks.
+/// * `dry_run` - Whether to perform a dry run or actually remove the checks.
+///
+/// # Panics
+///
+/// This function panics in the following situations:
+///
+/// * Unable to read the MPC checks directory or its metadata.
+fn clean_mpc_checks_path(path: &Path, keep: i64, dry_run: bool) {
+    let now = Local::now().naive_local();
+    match std::fs::read_dir(path) {
+        Ok(entries) => {
+            for entry in entries {
+                match entry {
+                    Ok(entry) => {
+                        match entry.metadata() {
+                            Ok(meta) => {
+                                if !meta.is_dir() {
+                                    continue;
+                                }
+                                let os_fn = entry.file_name();
+                                let file_name = os_fn.to_string_lossy();
+                                let date_time = datetime_from_dir(&file_name);
+                                let duration = now.signed_duration_since(date_time);
+                                if duration.num_days() >= keep {
+                                    clean_mpc_path(&entry.path(), dry_run);
+                                    // std::fs::remove_dir_all(entry.path())?;
+                                }
+                            }
+                            Err(e) => {
+                                panic!("Unable to read MPC checks in {:#?}.\n{:#?}", path, e);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        panic!("Unable to read MPC checks in {:#?}.\n{:#?}", path, e);
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            panic!("Unable to read MPC checks in {:#?}.\n{:#?}", path, e);
+        }
+    }
+}
+
+/// Cleans an MPC check directory by removing all files except "Results.xml" and "Results.csv".
+/// If `dry_run` is `true`, it only logs the files to be removed without actually removing them.
+///
+/// # Arguments
+///
+/// * `p` - The path to the MPC check directory.
+/// * `dry_run` - Specifies whether it is a dry run or not.
+///
+/// # Panics
+///
+/// This function will panic if:
+///
+/// * Unable to read the directory at `p`.
+/// * Unable to retrieve the metadata of a file.
+/// * The directory contains a subdirectory.
+/// * The directory contains a symbolic link.
+/// * Unable to remove a file.
+fn clean_mpc_path(p: &Path, dry_run: bool) {
+    match std::fs::read_dir(p) {
+        Ok(entries) => {
+            for entry in entries {
+                match entry {
+                    Ok(entry) => {
+                        match entry.metadata() {
+                            Ok(meta) => {
+                                if meta.is_dir() {
+                                    panic!("Unable to clean MPC checks directory {:#?}.\nOnly files are expected in this directory, not directories.", p);
+                                }
+                                if meta.is_symlink() {
+                                    panic!("Unable to clean MPC checks directory {:#?}.\nOnly files are expected in this directory, not symbolic links.", p);
+                                }
+                                let os_fn = entry.file_name();
+                                let file_name = os_fn.to_string_lossy();
+                                if file_name.as_ref() != "Results.xml" && file_name.as_ref() != "Results.csv" {
+                                    if dry_run {
+                                        info!("Removing: {:#?}", entry.path());
+                                    } else {
+                                        trace!("Removing: {:#?}", entry.path());
+                                        let err_msg = format!("Unable to clean MPC checks file: {:#?}", entry.path());
+                                        std::fs::remove_file(entry.path()).expect(&err_msg);
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                panic!("Unable to clean MPC checks directory {:#?}.\n{:#?}", p, e);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        panic!("Unable to clean MPC checks directory {:#?}.\n{:#?}", p, e);
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            panic!("Unable to clean MPC checks directory {:#?}.\n{:#?}", p, e);
+        }
+    }
+}
+
+/// Converts a directory name into a `NaiveDateTime` object.
+///
+/// The directory name should follow the format: `NDS-WKS-SN5783-2024-01-11-07-42-57-0000-BeamCheckTemplate6xFFF`.
+///
+/// # Arguments
+///
+/// * `s` - A string slice representing the directory name.
+///
+/// # Returns
+///
+/// Returns a `NaiveDateTime` object representing the date and time extracted from the directory name.
+///
+/// # Panics
+///
+/// This function will panic if the directory name does not have the correct format.
+fn datetime_from_dir(s: &str) -> NaiveDateTime {
+    let parts: Vec<&str> = s.split('-').collect();
+    if parts.len() != 11 {
+        panic!("Invalid directory name format detected in {:#?}", s);
+    }
+    let year = parts[3].parse::<i32>().unwrap();
+    let month = parts[4].parse::<u32>().unwrap();
+    let day = parts[5].parse::<u32>().unwrap();
+    let hour = parts[6].parse::<u32>().unwrap();
+    let minute = parts[7].parse::<u32>().unwrap();
+    let second = parts[8].parse::<u32>().unwrap();
+    NaiveDateTime::new(
+        NaiveDate::from_ymd_opt(year, month, day).unwrap(),
+        NaiveTime::from_hms_opt(hour, minute, second).unwrap(),
+    )
+}


### PR DESCRIPTION
The tool "mpc_checks_cleaner" has been added to the project. This command-line interface application is designed to clean MPC checks in the VA_TRANSFER share. Old MPC checks are removed based on a specified number of days. Commandline options such as dry-run, logging and version have been provided for better ease of use.