### PR TITLE
Add configurable retry mechanisms and state optimizations (fixes #24)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Cargo.lock
 
 .idea
 .vscode
+config.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["dcm_ls", "dcm_cp", "mpc_checks_cleaner", "one_way_sync"]
+members = ["dcm_ls", "dcm_cp", "mpc_checks_cleaner", "one_way_sync", "dcm_file_sort_service"]
 resolver = "2"
 
 [workspace.package]
@@ -32,6 +32,11 @@ chrono = "0.4"
 async-std = { version = "1", features = ["attributes"] }
 relative-path = "1"
 pathdiff = "0.2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tempfile = "3"
+ctrlc = "3"
+toml = "0.8"
 
 #[workspace.dev-dependencies]
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = "1"
 tempfile = "3"
 ctrlc = "3"
 toml = "0.8"
+filetime = "0.2"
 
 #[workspace.dev-dependencies]
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ async-std = { version = "1", features = ["attributes"] }
 relative-path = "1"
 pathdiff = "0.2"
 serde = { version = "1", features = ["derive"] }
+serde_with = "3"
 serde_json = "1"
 tempfile = "3"
 ctrlc = "3"

--- a/dcm_file_sort_service/Cargo.toml
+++ b/dcm_file_sort_service/Cargo.toml
@@ -24,7 +24,7 @@ toml.workspace = true
 tempfile.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-windows-service = "0.7"
+windows-service = "0.8.0"
 
 
 [[bin]]
@@ -34,3 +34,7 @@ path = "./src/bin/dcm_file_sort.rs"
 [[bin]]
 name = "dcm_file_sort_config_generation"
 path = "./src/bin/dcm_file_sort_config_generator.rs"
+
+[[bin]]
+name = "dcm_file_sort_service"
+path = "./src/bin/dcm_file_sort_service.rs"

--- a/dcm_file_sort_service/Cargo.toml
+++ b/dcm_file_sort_service/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "rad-tools-dcm-file-sort-service"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+thiserror.workspace = true
+clap.workspace = true
+walkdir.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+dicom-core.workspace = true
+dicom-object.workspace = true
+dicom-dictionary-std.workspace = true
+dicom-transfer-syntax-registry.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+ctrlc.workspace = true
+toml.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows-service = "0.7"
+
+
+[[bin]]
+name = "dcm_file_sort"
+path = "./src/bin/dcm_file_sort.rs"
+
+[[bin]]
+name = "dcm_file_sort_config_generation"
+path = "./src/bin/dcm_file_sort_config_generator.rs"

--- a/dcm_file_sort_service/Cargo.toml
+++ b/dcm_file_sort_service/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 authors.workspace = true
 
 [dependencies]
-anyhow.workspace = true
 thiserror.workspace = true
 clap.workspace = true
 walkdir.workspace = true
@@ -16,6 +15,7 @@ dicom-object.workspace = true
 dicom-dictionary-std.workspace = true
 dicom-transfer-syntax-registry.workspace = true
 serde.workspace = true
+serde_with.workspace = true
 serde_json.workspace = true
 ctrlc.workspace = true
 toml.workspace = true

--- a/dcm_file_sort_service/Cargo.toml
+++ b/dcm_file_sort_service/Cargo.toml
@@ -19,6 +19,7 @@ serde_with.workspace = true
 serde_json.workspace = true
 ctrlc.workspace = true
 toml.workspace = true
+filetime.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/dcm_file_sort_service/src/bin/dcm_file_sort.rs
+++ b/dcm_file_sort_service/src/bin/dcm_file_sort.rs
@@ -56,12 +56,7 @@ fn main() {
         .expect("Error setting Ctrl-C handler");
     }
     info!("Waiting for Ctrl-C ...");
-    if let Err(e) = run_service(
-        config.paths.input_dir,
-        config.paths.output_dir,
-        state.clone(),
-        10,
-    ) {
+    if let Err(e) = run_service(&config, state.clone(), 10) {
         error!("Failed to run service: {:?}", e);
     }
 }

--- a/dcm_file_sort_service/src/bin/dcm_file_sort.rs
+++ b/dcm_file_sort_service/src/bin/dcm_file_sort.rs
@@ -1,0 +1,42 @@
+use clap::Parser;
+use rad_tools_dcm_file_sort_service::{run_service, Cli};
+use std::sync::Arc;
+use tracing::{error, info, Level};
+
+fn main() {
+    let cli = Cli::parse();
+    let level = if cli.trace {
+        Level::TRACE
+    } else if cli.debug {
+        Level::DEBUG
+    } else if cli.verbose {
+        Level::INFO
+    } else {
+        Level::WARN
+    };
+    tracing_subscriber::fmt()
+        .with_thread_ids(true)
+        .with_target(true)
+        .with_max_level(level)
+        .init();
+
+    let state = Arc::new(std::sync::RwLock::new(
+        rad_tools_dcm_file_sort_service::ServiceState::Running,
+    ));
+    {
+        let moved_state = state.clone();
+        ctrlc::set_handler(move || match moved_state.try_write() {
+            Ok(mut inner) => {
+                *inner = rad_tools_dcm_file_sort_service::ServiceState::RequestToStop;
+            }
+            Err(_) => {
+                error!("Failed to get write lock on service state.");
+            }
+        })
+        .expect("Error setting Ctrl-C handler");
+    }
+    info!("Waiting for Ctrl-C ...");
+    if let Err(e) = run_service(cli.input_dir, cli.output_dir, state.clone(), 10) {
+        error!("Failed to run service: {:?}", e);
+    }
+}

--- a/dcm_file_sort_service/src/bin/dcm_file_sort.rs
+++ b/dcm_file_sort_service/src/bin/dcm_file_sort.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use rad_tools_dcm_file_sort_service::{run_service, Cli, Config};
+use rad_tools_dcm_file_sort_service::{Cli, Config, run_service};
 use tracing::{error, info};
 
 fn main() {
@@ -30,7 +30,7 @@ fn main() {
         .expect("Error setting Ctrl-C handler");
     }
     info!("Waiting for Ctrl-C ...");
-    if let Err(e) = run_service(&config, &rx, 10) {
+    if let Err(e) = run_service(&config, &rx) {
         error!("Failed to run service: {:?}", e);
     }
 }

--- a/dcm_file_sort_service/src/bin/dcm_file_sort.rs
+++ b/dcm_file_sort_service/src/bin/dcm_file_sort.rs
@@ -1,37 +1,16 @@
 use clap::Parser;
 use rad_tools_dcm_file_sort_service::{run_service, Cli, Config};
-use std::path::PathBuf;
 use std::sync::Arc;
-use tracing::{error, info, Level};
+use tracing::{error, info};
 
 fn main() {
     let cli = Cli::parse();
-    let config = if let Some(args) = cli.manual_args {
-        let mut config = Config::default();
-        config.paths.input_dir = PathBuf::from(args.input_dir);
-        config.paths.output_dir = PathBuf::from(args.output_dir);
-        config.paths.unknown_dir = PathBuf::from(args.unknown_dir);
-        config.log.level = if args.trace {
-            Level::TRACE
-        } else if args.debug {
-            Level::DEBUG
-        } else if args.verbose {
-            Level::INFO
-        } else {
-            Level::WARN
-        };
-        Some(config)
-    } else if let Some(config_path) = cli.config {
-        let config_content =
-            std::fs::read_to_string(config_path).expect("Failed to read the config file");
-        let config: Config =
-            toml::from_str(&config_content).expect("Failed to parse the config file");
-        Some(config)
-    } else {
-        None
-    };
-    if config.is_none() {
-        panic!("No config arguments or file provided");
+    let config = Config::try_from(cli);
+    if config.is_err() {
+        panic!(
+            "Unable to create a configuration from commandline arguments: {}",
+            config.err().unwrap()
+        );
     }
     let config = config.unwrap();
     tracing_subscriber::fmt()

--- a/dcm_file_sort_service/src/bin/dcm_file_sort.rs
+++ b/dcm_file_sort_service/src/bin/dcm_file_sort.rs
@@ -1,23 +1,43 @@
 use clap::Parser;
-use rad_tools_dcm_file_sort_service::{run_service, Cli};
+use rad_tools_dcm_file_sort_service::{run_service, Cli, Config};
+use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::{error, info, Level};
 
 fn main() {
     let cli = Cli::parse();
-    let level = if cli.trace {
-        Level::TRACE
-    } else if cli.debug {
-        Level::DEBUG
-    } else if cli.verbose {
-        Level::INFO
+    let config = if let Some(args) = cli.manual_args {
+        let mut config = Config::default();
+        config.paths.input_dir = PathBuf::from(args.input_dir);
+        config.paths.output_dir = PathBuf::from(args.output_dir);
+        config.paths.unknown_dir = PathBuf::from(args.unknown_dir);
+        config.log.level = if args.trace {
+            Level::TRACE
+        } else if args.debug {
+            Level::DEBUG
+        } else if args.verbose {
+            Level::INFO
+        } else {
+            Level::WARN
+        };
+        Some(config)
+    } else if let Some(config_path) = cli.config {
+        let config_content =
+            std::fs::read_to_string(config_path).expect("Failed to read the config file");
+        let config: Config =
+            toml::from_str(&config_content).expect("Failed to parse the config file");
+        Some(config)
     } else {
-        Level::WARN
+        None
     };
+    if config.is_none() {
+        panic!("No config arguments or file provided");
+    }
+    let config = config.unwrap();
     tracing_subscriber::fmt()
         .with_thread_ids(true)
         .with_target(true)
-        .with_max_level(level)
+        .with_max_level(config.log.level)
         .init();
 
     let state = Arc::new(std::sync::RwLock::new(
@@ -36,7 +56,12 @@ fn main() {
         .expect("Error setting Ctrl-C handler");
     }
     info!("Waiting for Ctrl-C ...");
-    if let Err(e) = run_service(cli.input_dir, cli.output_dir, state.clone(), 10) {
+    if let Err(e) = run_service(
+        config.paths.input_dir,
+        config.paths.output_dir,
+        state.clone(),
+        10,
+    ) {
         error!("Failed to run service: {:?}", e);
     }
 }

--- a/dcm_file_sort_service/src/bin/dcm_file_sort_config_generator.rs
+++ b/dcm_file_sort_service/src/bin/dcm_file_sort_config_generator.rs
@@ -1,0 +1,107 @@
+use clap::Parser;
+use rad_tools_dcm_file_sort_service::Config;
+use std::io::Write;
+use std::path::PathBuf;
+
+/// A command line interface (CLI) application to generate a configuration file used by dcm_file_sort.
+#[derive(Parser, Debug, Clone)]
+#[command(
+    author,
+    version,
+    about,
+    long_about = "
+A command line interface (CLI) application to generate a configuration file used by dcm_file_sort.
+"
+)]
+struct Cli {
+    /// Path where the config file is written.
+    #[arg(short, long, default_value = "config.toml")]
+    pub output: String,
+    /// Interactive mode
+    #[arg(short, long, default_value_t = false)]
+    interactive: bool,
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    let mut config = Config::default();
+    if cli.interactive {
+        config.paths.input_dir = PathBuf::from(ask_question("Input directory"));
+        config.paths.output_dir = PathBuf::from(ask_question("Output directory"));
+        config.paths.unknown_dir = PathBuf::from(ask_question(
+            "Directory for data that couldn't be processed",
+        ));
+        config.log.level = ask_question_with_default("Log level", "info");
+        config.other.wait_time_millisec =
+            ask_question_with_default("Wait time in milliseconds", "500")
+                .parse::<u64>()
+                .unwrap();
+    }
+
+    let s = toml::to_string_pretty(&config).unwrap();
+
+    let mut file = std::fs::File::create(cli.output).expect("Failed to create output file");
+    file.write_all(s.as_bytes())
+        .expect("Failed to write to output file");
+}
+
+/// Prompts the user with a question and waits for a non-empty response.
+///
+/// The function prints the provided question, followed by a colon and a space, to
+/// the standard output. It then waits for the user's input. If the input is valid
+/// and non-empty, it returns the response as a `String`. If the input is empty,
+/// an error message is displayed, and the user is prompted again until a valid
+/// non-empty response is provided.
+///
+/// # Parameters
+/// - `question`: A string slice that holds the question to be presented to the user.
+///
+/// # Returns
+/// A `String` containing the user's response.
+fn ask_question(question: &str) -> String {
+    use std::io::Write;
+
+    loop {
+        print!("{}: ", question);
+        std::io::stdout().flush().unwrap();
+
+        let mut response = String::new();
+        if std::io::stdin().read_line(&mut response).is_ok() {
+            let response = response.trim();
+            if !response.is_empty() {
+                return response.to_string();
+            }
+        }
+
+        println!("Response cannot be empty. Please try again.");
+    }
+}
+
+/// Prompts the user with a question and a default value, and waits for a response.
+///
+/// The function displays the provided question along with a default value in square brackets.
+/// The user can either input a value or press Enter to accept the default.
+/// If the input is empty, the default value is returned.
+///
+/// # Parameters
+/// - `question`: A string slice representing the question to present to the user.
+/// - `default`: A string slice representing the default value to use if no input is provided.
+///
+/// # Returns
+/// A `String` containing either the user's response or the provided default value if
+/// the user does not input anything.
+fn ask_question_with_default(question: &str, default: &str) -> String {
+    let new_question = format!("{} [default={}]", question, default);
+    print!("{}", new_question);
+    std::io::stdout().flush().unwrap();
+
+    let mut response = String::new();
+    std::io::stdin().read_line(&mut response).unwrap();
+    let response = response.trim();
+    if response.is_empty() {
+        default.to_string()
+    } else {
+        response.to_string()
+    }
+}

--- a/dcm_file_sort_service/src/bin/dcm_file_sort_config_generator.rs
+++ b/dcm_file_sort_service/src/bin/dcm_file_sort_config_generator.rs
@@ -2,6 +2,8 @@ use clap::Parser;
 use rad_tools_dcm_file_sort_service::Config;
 use std::io::Write;
 use std::path::PathBuf;
+use std::str::FromStr;
+use tracing::Level;
 
 /// A command line interface (CLI) application to generate a configuration file used by dcm_file_sort.
 #[derive(Parser, Debug, Clone)]
@@ -32,7 +34,8 @@ fn main() {
         config.paths.unknown_dir = PathBuf::from(ask_question(
             "Directory for data that couldn't be processed",
         ));
-        config.log.level = ask_question_with_default("Log level", "info");
+        config.log.level = Level::from_str(ask_question_with_default("Log level", "info").as_str())
+            .expect("Failed to parse log level");
         config.other.wait_time_millisec =
             ask_question_with_default("Wait time in milliseconds", "500")
                 .parse::<u64>()
@@ -92,7 +95,7 @@ fn ask_question(question: &str) -> String {
 /// A `String` containing either the user's response or the provided default value if
 /// the user does not input anything.
 fn ask_question_with_default(question: &str, default: &str) -> String {
-    let new_question = format!("{} [default={}]", question, default);
+    let new_question = format!("{} [default={}]: ", question, default);
     print!("{}", new_question);
     std::io::stdout().flush().unwrap();
 

--- a/dcm_file_sort_service/src/bin/dcm_file_sort_service.rs
+++ b/dcm_file_sort_service/src/bin/dcm_file_sort_service.rs
@@ -1,0 +1,13 @@
+const SERVICE_NAME: &str = "DicomFileSortService";
+const SERVICE_DISPLAY_NAME: &str = "Dicom File Sort Service";
+const SERVICE_DESCRIPTION: &str = "Service to sort DICOM files by patient ID and date of birth";
+
+#[cfg(windows)]
+fn main() {
+    println!("Start the service");
+}
+
+#[cfg(not(windows))]
+fn main() {
+    panic!("This service is only intented to run on Windows");
+}

--- a/dcm_file_sort_service/src/cli.rs
+++ b/dcm_file_sort_service/src/cli.rs
@@ -1,0 +1,36 @@
+use clap::Parser;
+
+/// An application to sort DICOM data from an input directory into an output directory.
+///
+/// An application to sort DICOM data from an input directory into an output directory.
+/// The data is sorted based on the date of birth and the patient ID (format: <output dir>/<MMDD>/<patient ID>.
+/// The name of the DICOM file is based on the modality and the (unique) SOP instance UID.
+#[derive(Parser, Debug, Clone)]
+#[command(
+    author,
+    version,
+    about,
+    long_about = "
+An application to sort DICOM data from an input directory into an output directory.
+
+An application to sort DICOM data from an input directory into an output directory.
+The data is sorted based on the date of birth and the patient ID (format: <output dir>/<MMDD>/<patient ID>.
+The name of the DICOM file is based on the modality and the (unique) SOP instance UID."
+)]
+pub struct Cli {
+    /// Directory where the DICOM data are read from.
+    #[arg(short, long)]
+    pub input_dir: String,
+    /// Directory where the DICOM data is written to.
+    #[arg(short, long)]
+    pub output_dir: String,
+    /// Enable logging at INFO level.
+    #[arg(long, default_value_t = false)]
+    pub verbose: bool,
+    /// Enable logging at DEBUG level.
+    #[arg(long, default_value_t = false)]
+    pub debug: bool,
+    /// Enable logging at TRACE level.
+    #[arg(long, default_value_t = false)]
+    pub trace: bool,
+}

--- a/dcm_file_sort_service/src/cli.rs
+++ b/dcm_file_sort_service/src/cli.rs
@@ -1,3 +1,4 @@
+use clap::Args;
 use clap::Parser;
 
 /// An application to sort DICOM data from an input directory into an output directory.
@@ -18,12 +19,43 @@ The data is sorted based on the date of birth and the patient ID (format: <outpu
 The name of the DICOM file is based on the modality and the (unique) SOP instance UID."
 )]
 pub struct Cli {
+    // /// Directory where the DICOM data are read from.
+    // #[arg(short, long, group = "manual")]
+    // pub input_dir: Option<String>,
+    // /// Directory where the DICOM data is written to.
+    // #[arg(short, long, group = "manual")]
+    // pub output_dir: Option<String>,
+    // /// Directory where files that couldn't be processed are moved.
+    // #[arg(short, long, group = "manual")]
+    // pub unknown_dir: Option<String>,
+    // /// Enable logging at INFO level.
+    // #[arg(long, default_value_t = false, group = "manual")]
+    // pub verbose: bool,
+    // /// Enable logging at DEBUG level.
+    // #[arg(long, default_value_t = false, group = "manual")]
+    // pub debug: bool,
+    // /// Enable logging at TRACE level.
+    // #[arg(long, default_value_t = false, group = "manual")]
+    // pub trace: bool,
+    #[command(flatten)]
+    pub manual_args: Option<ManualArgs>,
+
+    #[arg(short, long, group = "conf", conflicts_with = "ManualArgs")]
+    pub config: Option<String>,
+}
+
+#[derive(Args, Debug, Clone)]
+#[group(required = false, multiple = false)]
+pub struct ManualArgs {
     /// Directory where the DICOM data are read from.
     #[arg(short, long)]
     pub input_dir: String,
     /// Directory where the DICOM data is written to.
     #[arg(short, long)]
     pub output_dir: String,
+    /// Directory where files that couldn't be processed are moved.
+    #[arg(short, long)]
+    pub unknown_dir: String,
     /// Enable logging at INFO level.
     #[arg(long, default_value_t = false)]
     pub verbose: bool,
@@ -33,4 +65,11 @@ pub struct Cli {
     /// Enable logging at TRACE level.
     #[arg(long, default_value_t = false)]
     pub trace: bool,
+}
+
+#[derive(Args, Debug, Clone)]
+#[group(required = false, multiple = false)]
+pub struct ConfigArgs {
+    #[arg(short, long)]
+    pub config: String,
 }

--- a/dcm_file_sort_service/src/config.rs
+++ b/dcm_file_sort_service/src/config.rs
@@ -1,0 +1,48 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Directories where the data is read from and written to.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+pub struct Paths {
+    /// Input directory where the DICOM data is initially stored
+    pub input_dir: PathBuf,
+    /// Output directory where the DICOM data is moved to.
+    pub output_dir: PathBuf,
+    /// Data that can't be processed will be moved into this directory.
+    pub unknown_dir: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Log {
+    pub level: String,
+}
+
+impl Default for Log {
+    fn default() -> Self {
+        Self {
+            level: "info".to_string(),
+        }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Other {
+    pub wait_time_millisec: u64,
+}
+
+impl Default for Other {
+    fn default() -> Self {
+        Self {
+            wait_time_millisec: 500,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+pub struct Config {
+    /// Paths required for reading and writing the data
+    pub paths: Paths,
+    /// Logging configuration
+    pub log: Log,
+    /// Other config
+    pub other: Other,
+}

--- a/dcm_file_sort_service/src/config.rs
+++ b/dcm_file_sort_service/src/config.rs
@@ -1,12 +1,12 @@
 use crate::{Cli, Error};
 use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
 use serde_with::DisplayFromStr;
+use serde_with::serde_as;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 use std::str::FromStr;
-use tracing::metadata::ParseLevelError;
 use tracing::Level;
+use tracing::metadata::ParseLevelError;
 
 /// Directories where the data is read from and written to.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
@@ -62,13 +62,26 @@ impl FromStr for Log {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Other {
+    /// The number of milliseconds a thread will sleep after moving data in a directory. After this delay, the thread will process new files in the input directory.
     pub wait_time_millisec: u64,
+    /// The number of milliseconds a thread will sleep if a file can't be copied or removed because the file resource is being used by another process.
+    pub io_timeout_millisec: u64,
+    /// Number of times the service will try to copy a file if the input file resource is being used by another process.
+    pub copy_attempts: u64,
+    /// Number of times the service will try to remove a file
+    pub remove_attempts: usize,
+    /// Number of seconds between the last modified time and the current time before a file is consided deletable.
+    pub mtime_delay_secs: i64,
 }
 
 impl Default for Other {
     fn default() -> Self {
         Self {
             wait_time_millisec: 500,
+            io_timeout_millisec: 500,
+            copy_attempts: 100,
+            remove_attempts: 10,
+            mtime_delay_secs: 10,
         }
     }
 }

--- a/dcm_file_sort_service/src/config.rs
+++ b/dcm_file_sort_service/src/config.rs
@@ -82,6 +82,30 @@ pub struct Config {
     pub other: Other,
 }
 
+impl Config {
+    /// Ensures that the directories specified in the `paths` field of the `Config` struct exist.
+    ///
+    /// This function checks for the existence of the input, output, and unknown directories
+    /// specified in the `Paths` struct. If any of these directories do not exist, it will create them.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - If all directories exist or are successfully created.
+    /// * `Err(std::io::Error)` - If an error occurs while creating any of the directories.
+    pub fn create_dirs(&self) -> Result<(), std::io::Error> {
+        if !self.paths.input_dir.exists() {
+            std::fs::create_dir_all(&self.paths.input_dir)?;
+        }
+        if !self.paths.output_dir.exists() {
+            std::fs::create_dir_all(&self.paths.output_dir)?;
+        }
+        if !self.paths.unknown_dir.exists() {
+            std::fs::create_dir_all(&self.paths.unknown_dir)?;
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/dcm_file_sort_service/src/config.rs
+++ b/dcm_file_sort_service/src/config.rs
@@ -62,7 +62,7 @@ impl FromStr for Log {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Other {
-    /// The number of milliseconds a thread will sleep after moving data in a directory. After this delay, the thread will process new files in the input directory.
+    /// The number of milliseconds a thread will sleep after moving data from the input directory to the output directory. After this delay, the thread will process new files in the input directory.
     pub wait_time_millisec: u64,
     /// The number of milliseconds a thread will sleep if a file can't be copied or removed because the file resource is being used by another process.
     pub io_timeout_millisec: u64,

--- a/dcm_file_sort_service/src/lib.rs
+++ b/dcm_file_sort_service/src/lib.rs
@@ -1,0 +1,568 @@
+mod cli;
+mod config;
+
+pub use cli::Cli;
+pub use config::Config;
+
+use crate::Error::InvalidDateOfBirth;
+use dicom_object::{open_file, ReadError};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+use tracing::{debug, error, info, trace};
+use walkdir::WalkDir;
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, Ord, PartialOrd)]
+pub enum ServiceState {
+    Running,
+    RequestToStop,
+    Stopped,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("IO error: {0}")]
+    IO(#[from] std::io::Error),
+    #[error("Read error: {0}")]
+    DicomRead(#[from] ReadError),
+    #[error("Walk directory error: {0}")]
+    WalkDir(#[from] walkdir::Error),
+    #[error("Invalid date of birth format")]
+    InvalidDateOfBirth,
+    #[error("Unable to parse integer from string")]
+    ParseIntError(#[from] std::num::ParseIntError),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Data used to sort the DICOM file
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+pub(crate) struct SortingData {
+    /// SOP Instance UID
+    pub sop_instance_uid: String,
+    /// Modality
+    pub modality: String,
+    /// Patient ID
+    pub patient_id: String,
+    /// Date of birth
+    pub date_of_birth: String,
+    /// DICOM file to be sorted
+    pub path: PathBuf,
+}
+
+///
+/// Represents the movement of a file from an input path to an output path.
+///
+/// This struct is used to log and track the relocation of files during processing.
+///
+/// # Fields
+/// * `input` - The original file path where the DICOM file was located.
+/// * `output` - The destination file path where the DICOM file was moved.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+pub(crate) struct MovedData {
+    /// Input file path
+    pub input: PathBuf,
+    /// Output file path
+    pub output: PathBuf,
+}
+
+impl std::fmt::Display for MovedData {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "Moved {} to {}",
+            self.input.display(),
+            self.output.display()
+        )
+    }
+}
+
+pub fn run_service<P: AsRef<Path>>(
+    input_dir: P,
+    output_dir: P,
+    state: Arc<RwLock<ServiceState>>,
+    wait_millisecs: u64,
+) -> Result<()> {
+    'outer: loop {
+        let to_sort = get_sorting_data(&input_dir, state.clone())?;
+        // if to_sort.is_empty() {
+        //     std::thread::sleep(std::time::Duration::from_millis(wait_millisecs));
+        //     if should_stop(&state) {
+        //         break 'outer;
+        //     }
+        //     continue;
+        // }
+        for sd in to_sort {
+            if should_stop(&state) {
+                break 'outer;
+            }
+            match copy_dicom_data(sd, &output_dir) {
+                Ok(moved_data) => {
+                    info!(
+                        "Moved {} to {}",
+                        moved_data.input.display(),
+                        moved_data.output.display()
+                    );
+                    std::fs::remove_file(moved_data.input)?;
+                }
+                Err(e) => {
+                    error!("Failed to move file: {}", e);
+                }
+            }
+        }
+        remove_empty_sub_dirs(&input_dir)?;
+        if should_stop(&state) {
+            break 'outer;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(wait_millisecs));
+    }
+    Ok(())
+}
+
+fn should_stop(state: &Arc<RwLock<ServiceState>>) -> bool {
+    if let Ok(inner) = state.try_read() {
+        if *inner != ServiceState::Running {
+            return true;
+        }
+    }
+    false
+}
+
+///
+/// Iterates over the files in the given directory and gathers sorting data for DICOM files.
+///
+/// This function traverses the specified directory and its subdirectories, examining each
+/// file to determine if it is a DICOM file. If so, it attempts to extract metadata and collects
+/// it as `SortingData`. The function monitors the shared `state` to ensure it halts processing if
+/// the service state is no longer `ServiceState::Running`.
+///
+/// # Arguments
+/// * `input_dir` - The directory to scan for DICOM files.
+/// * `state` - A shared atomic state indicating whether the service should continue running.
+///
+/// # Returns
+/// * `Ok(Vec<SortingData>)` - A vector containing `SortingData` for identified DICOM files.
+/// * `Err` - If an error occurs during the directory traversal or file processing.
+///
+/// # Behavior
+/// * The function stops processing if the service changes to a non-running state.
+/// * Errors during metadata extraction for individual files are logged but do not stop execution.
+///
+/// # Errors
+/// * Returns an error if a directory traversal issue occurs or if it encounters a critical failure
+///   while processing files.
+fn get_sorting_data<P: AsRef<Path>>(
+    input_dir: P,
+    state: Arc<RwLock<ServiceState>>,
+) -> Result<Vec<SortingData>> {
+    let mut v = vec![];
+    // for entry in WalkDir::new(&input_dir).into_iter().filter_map(|r| r.ok()) {
+    for entry in WalkDir::new(&input_dir) {
+        match entry {
+            Ok(entry) => {
+                trace!("Processing file: {}", entry.path().display());
+                if should_stop(&state) {
+                    info!("Stopping processing cycle");
+                    break;
+                }
+                let path = entry.path();
+
+                if !path.is_file() {
+                    continue;
+                }
+                match extract_dicom_metadata(path) {
+                    Ok(Some(sorting_data)) => {
+                        v.push(sorting_data);
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        // It might not be a DICOM file
+                        error!("Failed to process file {}: {}", path.display(), e);
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Failed to traverse directory: {}", e);
+                continue;
+            }
+        }
+    }
+    Ok(v)
+}
+
+///
+/// Recursively removes empty subdirectories within the specified directory.
+///
+/// This function traverses the given directory and its subdirectories, identifying
+/// directories that are empty and removing them. It ensures that no non-empty
+/// directories are removed, and it operates silently on errors, logging them
+/// when necessary.
+///
+/// # Arguments
+/// * `dir` - The root directory to scan for empty subdirectories.
+///
+/// # Errors
+/// Returns an error if there is an issue accessing the directory or removing
+/// a directory. Errors during traversal, such as permission issues, are also
+/// propagated.
+///
+/// # Behavior
+/// * Empty subdirectories are removed.
+/// * Directories containing at least one file or subdirectory are left untouched.
+fn remove_empty_sub_dirs<P: AsRef<Path>>(dir: P) -> Result<()> {
+    for entry in WalkDir::new(&dir).into_iter().filter_map(|r| r.ok()) {
+        let path = entry.path();
+        if path == dir.as_ref() {
+            continue;
+        }
+        if path.is_dir() && is_dir_empty(path) {
+            std::fs::remove_dir_all(path)?;
+        }
+    }
+    Ok(())
+}
+
+///
+/// Extracts metadata from a DICOM file, specifically the Patient ID and Date of Birth.
+/// If the birthday doesn't exist and the patient ID is 8 characters or longer, the 3, 4, 5 and 7th character are used as a substitue.
+///
+/// # Arguments
+/// * `file_path` - A path to the DICOM file to be processed.
+///
+/// # Returns
+/// * `Ok(Some(SortingData))` - If both Patient ID and Date of Birth are successfully extracted.
+/// * `Ok(None)` - If the required metadata is missing or cannot be extracted.
+/// * `Err` - If the DICOM file cannot be opened or read.
+///
+/// # Errors
+/// This function returns an error if there is an issue opening the DICOM file or reading its
+/// contents. Individual metadata extraction errors are logged but do not cause the function
+/// to return an error.
+///
+/// The extracted metadata is represented as a `SortingData` struct containing the following:
+/// * `patient_id` - The Patient ID (DICOM Tag: (0010,0020)) as a string.
+/// * `date_of_birth` - The Date of Birth (DICOM Tag: (0010,0030)) as a string.
+fn extract_dicom_metadata<P: AsRef<Path>>(file_path: P) -> Result<Option<SortingData>> {
+    let dicom_file = open_file(file_path.as_ref())?;
+
+    let sop_instance_uid = dicom_file
+        .element_by_name("SOPInstanceUID")
+        .ok()
+        .and_then(|elem| match elem.string() {
+            Ok(s) => Some(s.trim().to_string()),
+            Err(e) => {
+                error!("Failed to extract SOP Instance UID: {}", e);
+                None
+            }
+        });
+
+    let modality = dicom_file
+        .element_by_name("Modality")
+        .ok()
+        .and_then(|elem| match elem.string() {
+            Ok(s) => Some(s.trim().to_string()),
+            Err(e) => {
+                error!("Failed to extract Modality: {}", e);
+                None
+            }
+        });
+
+    // Extracting Patient ID (Tag: (0010,0020)) and Date of Birth (Tag: (0010,0030)).
+    let patient_id = dicom_file
+        .element_by_name("PatientID")
+        .ok()
+        .and_then(|elem| match elem.string() {
+            Ok(s) => Some(s.trim().to_string()),
+            Err(e) => {
+                error!("Failed to extract Patient ID: {}", e);
+                None
+            }
+        });
+
+    let date_of_birth = dicom_file
+        .element_by_name("PatientBirthDate")
+        .ok()
+        .and_then(|elem| match elem.string() {
+            Ok(s) => Some(s.trim().to_string()),
+            Err(e) => {
+                error!("Failed to extract Date of Birth: {}.\nTrying to extract part of the patient ID.", e);
+                if let Some(pid) = patient_id.as_ref() {
+                    let t = format!("00{}", &pid[0..6]);
+                    return Some(t);
+                }
+                None
+            }
+        });
+
+    if let (Some(sop_instance_uid), Some(modality), Some(pid), Some(dob)) =
+        (sop_instance_uid, modality, patient_id, date_of_birth)
+    {
+        Ok(Some(SortingData {
+            sop_instance_uid,
+            modality,
+            patient_id: pid,
+            date_of_birth: dob,
+            path: file_path.as_ref().to_path_buf(),
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+///
+/// Copies a DICOM file to a designated output directory based on its metadata.
+///
+/// # Arguments
+/// * `data` - A `SortingData` struct containing metadata (e.g., Patient ID and Date of Birth) and the original file path.
+/// * `output_dir` - The path to the output directory where the file should be copied.
+///
+/// # Returns
+/// * `Ok(MovedData)` - If the file is successfully copied to the output directory.
+/// * `Err` - If any error occurs during the directory creation, file copying, or if the metadata does not adhere to expected formats.
+///
+/// # Errors
+/// * Returns an error if the output directory cannot be created.
+/// * Returns an error if the provided date of birth format is invalid (not in `YYYYMMDD` format).
+/// * Returns an error if the source file name is invalid or missing.
+///
+/// # Behavior
+/// * Organizes files in the output directory using the patient's date of birth (as a `MMDD` folder structure)
+///   and their Patient ID.
+/// * If the specified directories in the output path do not exist, they are created automatically.
+/// * Uses the `tracing` crate to log any errors, such as invalid date of birth format or issues with file copying.
+///
+/// # Assumptions
+/// * `date_of_birth` in `SortingData` is expected to be in the format `YYYYMMDD`. Non-matching formats will result in an error.
+///
+fn copy_dicom_data<P: AsRef<Path>>(data: SortingData, output_dir: P) -> Result<MovedData> {
+    // Extract the date of birth and patient ID from SortingData
+    let dob = &data.date_of_birth;
+    let patient_id = &data.patient_id;
+    let source_path = &data.path;
+
+    // Ensure date of birth is in valid format (YYYYMMDD). In case of invalid format, return an error.
+    if dob.len() != 8 {
+        error!("Invalid date of birth format: {}", dob);
+        return Err(InvalidDateOfBirth);
+    }
+
+    let month_day = &dob[4..]; // Extract MMDD part
+    let month = month_day[0..2].parse::<i32>()?;
+    let day = month_day[2..].parse::<i32>()?;
+    if month <= 0 || month > 12 || day <= 0 || day > 31 {
+        error!("Invalid date of birth format: {}", dob);
+        return Err(InvalidDateOfBirth);
+    }
+    let output_path =
+        output_dir
+            .as_ref()
+            .join(format!("{}/{}", month_day.trim(), patient_id.trim()));
+
+    // Create the necessary directories if they do not already exist
+    debug!("Creating output directory: {}", output_path.display());
+    if let Err(e) = std::fs::create_dir_all(&output_path) {
+        if e.kind() != std::io::ErrorKind::AlreadyExists {
+            return Err(e.into());
+        }
+    }
+
+    // Construct the final file path in the output directory
+    let dest_file_path =
+        output_path.join(format!("{}{}.dcm", &data.modality, &data.sop_instance_uid));
+
+    debug!(
+        "Copying file: {} -> {}",
+        source_path.display(),
+        dest_file_path.display()
+    );
+    // Copy the file to the destination path
+    std::fs::copy(source_path, &dest_file_path)?;
+
+    Ok(MovedData {
+        input: data.path,
+        output: dest_file_path,
+    })
+}
+
+/// Checks whether a given directory is empty.
+///
+/// This function takes a path reference and determines if the directory
+/// contains any entries. If the directory exists and contains no entries,
+/// it returns `true`. Otherwise, it returns `false`.
+///
+/// # Arguments
+///
+/// * `dir` - A path reference to the directory to check.
+///
+/// # Returns
+///
+/// * `true` if the directory is empty or does not contain any entries.
+/// * `false` if the directory contains at least one entry or if an error occurs while reading the directory.
+fn is_dir_empty<P: AsRef<Path>>(dir: P) -> bool {
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        return entries.count() == 0;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dicom_core::{DataElement, PrimitiveValue};
+    use dicom_dictionary_std::tags;
+    use dicom_dictionary_std::uids::CT_IMAGE_STORAGE;
+    use dicom_object::{FileMetaTableBuilder, InMemDicomObject};
+
+    fn create_test_dicom_file(
+        patient_id: &str,
+        date_of_birth: &str,
+        output_file_path: &Path,
+    ) -> Result<()> {
+        let mut obj = InMemDicomObject::new_empty();
+
+        obj.put(DataElement::new(
+            tags::SOP_INSTANCE_UID,
+            dicom_core::VR::UI,
+            PrimitiveValue::from("1.2.40.0.13.1.224652156348011029364280439841088994139"),
+        ));
+
+        obj.put(DataElement::new(
+            tags::MODALITY,
+            dicom_core::VR::CS,
+            PrimitiveValue::from("CT"),
+        ));
+
+        // Add Patient ID
+        obj.put(DataElement::new(
+            tags::PATIENT_ID,
+            dicom_core::VR::LO,
+            PrimitiveValue::from(patient_id.to_string()),
+        ));
+
+        // Add Patient Date of Birth
+        obj.put(DataElement::new(
+            tags::PATIENT_BIRTH_DATE,
+            dicom_core::VR::DA,
+            PrimitiveValue::from(date_of_birth.to_string()),
+        ));
+
+        // Write the DICOM object to a file
+        let file_obj = obj
+            .with_meta(
+                FileMetaTableBuilder::new()
+                    .transfer_syntax(dicom_transfer_syntax_registry::default().erased().uid())
+                    .media_storage_sop_class_uid(CT_IMAGE_STORAGE),
+            )
+            .unwrap();
+        file_obj.write_to_file(output_file_path).unwrap();
+        Ok(())
+    }
+
+    #[test]
+    fn test_copy_dicom_data_success() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let input_dir = temp_dir.path().join("input");
+        let output_dir = temp_dir.path().join("output");
+        std::fs::create_dir_all(&input_dir).unwrap();
+        std::fs::create_dir_all(&output_dir).unwrap();
+        let patient_id = "12345";
+        let date_of_birth = "19850615";
+        let input_file = input_dir.join("test.dcm");
+
+        let r = create_test_dicom_file(patient_id, date_of_birth, &input_file);
+        if r.as_ref().is_err() {
+            panic!("Failed to create test file: {:?}", r);
+        }
+        assert!(r.is_ok());
+
+        let sorting_data = SortingData {
+            sop_instance_uid: "9.3.12.2.1107.5.1.7.130037.30000025021708505036500000024"
+                .to_string(),
+            modality: "CT".to_string(),
+            patient_id: patient_id.to_string(),
+            date_of_birth: date_of_birth.to_string(),
+            path: input_file.clone(),
+        };
+
+        let output_file_name = format!(
+            "{}{}.dcm",
+            &sorting_data.modality, &sorting_data.sop_instance_uid
+        );
+
+        // Call the function
+        let moved_data = copy_dicom_data(sorting_data, &output_dir).unwrap();
+
+        // Validate that the file was copied to the correct output directory
+        let expected_output_path = output_dir
+            .join(&date_of_birth[4..])
+            .join(patient_id)
+            .join(output_file_name);
+        debug!("Expected output path: {}", expected_output_path.display());
+        debug!("Actual output path: {}", moved_data.output.display());
+        assert!(moved_data.output.exists());
+        // assert!(expected_output_path.exists());
+
+        // Validate the channel message
+        assert_eq!(moved_data.input, input_file);
+        assert_eq!(moved_data.output, expected_output_path);
+        std::fs::remove_dir_all(temp_dir).unwrap()
+    }
+
+    #[test]
+    fn test_copy_dicom_data_invalid_date_of_birth_format() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let input_dir = temp_dir.path().join("input");
+        let output_dir = temp_dir.path().join("output");
+        std::fs::create_dir_all(&input_dir).unwrap();
+        std::fs::create_dir_all(&output_dir).unwrap();
+        let patient_id = "12345";
+        let invalid_date_of_birth = "1985";
+        let input_file = input_dir.join("test.dcm");
+
+        let sorting_data = SortingData {
+            sop_instance_uid: "9.3.12.2.1107.5.1.7.130037.30000025021708505036500000024"
+                .to_string(),
+            modality: "CT".to_string(),
+            patient_id: patient_id.to_string(),
+            date_of_birth: invalid_date_of_birth.to_string(),
+            path: input_file.clone(),
+        };
+
+        // Call the function
+        let result = copy_dicom_data(sorting_data, &output_dir);
+
+        // Validate that the function returns an error
+        assert!(result.is_err());
+
+        // Validate that the file was not copied
+        assert!(is_dir_empty(&output_dir));
+        std::fs::remove_dir_all(temp_dir).unwrap()
+    }
+
+    #[test]
+    fn test_copy_dicom_data_missing_source_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let input_dir = temp_dir.path().join("input");
+        let output_dir = temp_dir.path().join("output");
+        std::fs::create_dir_all(&input_dir).unwrap();
+        std::fs::create_dir_all(&output_dir).unwrap();
+        let patient_id = "12345";
+        let date_of_birth = "19850615";
+        let input_file = input_dir.join("test.dcm");
+
+        let sorting_data = SortingData {
+            sop_instance_uid: "9.3.12.2.1107.5.1.7.130037.30000025021708505036500000024"
+                .to_string(),
+            modality: "CT".to_string(),
+            patient_id: patient_id.to_string(),
+            date_of_birth: date_of_birth.to_string(),
+            path: input_file.clone(),
+        };
+
+        // Call the function
+        let result = copy_dicom_data(sorting_data, &output_dir);
+
+        // Validate that the function returns an error
+        assert!(result.is_err());
+    }
+}

--- a/dcm_file_sort_service/src/lib.rs
+++ b/dcm_file_sort_service/src/lib.rs
@@ -33,6 +33,8 @@ pub enum Error {
     ParseIntError(#[from] std::num::ParseIntError),
     #[error("Unable to determine filename")]
     UnknownFilename,
+    #[error("Unable to create config from Cli")]
+    ConfigFromCli,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/dcm_file_sort_service/src/lib.rs
+++ b/dcm_file_sort_service/src/lib.rs
@@ -9,7 +9,7 @@ use dicom_object::{open_file, ReadError};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
 use walkdir::WalkDir;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, Ord, PartialOrd)]
@@ -31,13 +31,15 @@ pub enum Error {
     InvalidDateOfBirth,
     #[error("Unable to parse integer from string")]
     ParseIntError(#[from] std::num::ParseIntError),
+    #[error("Unable to determine filename")]
+    UnknownFilename,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Data used to sort the DICOM file
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
-pub(crate) struct SortingData {
+pub struct DicomData {
     /// SOP Instance UID
     pub sop_instance_uid: String,
     /// Modality
@@ -50,27 +52,41 @@ pub(crate) struct SortingData {
     pub path: PathBuf,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+pub struct UnknownData {
+    /// Path to the unknown data
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+pub enum SortingData {
+    #[default]
+    None,
+    Dicom(DicomData),
+    Unknown(UnknownData),
+}
+
 ///
-/// Represents the movement of a file from an input path to an output path.
+/// Represents the copy of a file from an input path to an output path.
 ///
 /// This struct is used to log and track the relocation of files during processing.
 ///
 /// # Fields
-/// * `input` - The original file path where the DICOM file was located.
-/// * `output` - The destination file path where the DICOM file was moved.
+/// * `input` - The original file path where the file is located.
+/// * `output` - The destination file path where the file is copied to.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
-pub(crate) struct MovedData {
+pub(crate) struct CopiedData {
     /// Input file path
     pub input: PathBuf,
     /// Output file path
     pub output: PathBuf,
 }
 
-impl std::fmt::Display for MovedData {
+impl std::fmt::Display for CopiedData {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "Moved {} to {}",
+            "Copied {} to {}",
             self.input.display(),
             self.output.display()
         )
@@ -83,24 +99,32 @@ pub fn run_service(
     wait_millisecs: u64,
 ) -> Result<()> {
     'outer: loop {
-        let to_sort = get_sorting_data(config, state.clone())?;
-        for sd in to_sort {
+        let (vdd, unknowns) = get_sorting_data(config, state.clone())?;
+        let handle_copied_data = |r: Result<CopiedData>| -> Result<()> {
+            match r {
+                Ok(copied_data) => match std::fs::remove_file(&copied_data.input) {
+                    Ok(_) => {
+                        debug!("Removed file: {}", copied_data.input.display());
+                        Ok(())
+                    }
+                    Err(e) => Err(Error::IO(e)),
+                },
+                Err(e) => Err(e),
+            }
+        };
+        // Process the DICOM data
+        for dd in vdd {
             if should_stop(&state) {
                 break 'outer;
             }
-            match copy_dicom_data(sd, config) {
-                Ok(moved_data) => {
-                    info!(
-                        "Moved {} to {}",
-                        moved_data.input.display(),
-                        moved_data.output.display()
-                    );
-                    std::fs::remove_file(moved_data.input)?;
-                }
-                Err(e) => {
-                    error!("Failed to move file: {}", e);
-                }
+            handle_copied_data(copy_dicom_data(dd, config))?;
+        }
+        // Process the unkown data
+        for ud in unknowns {
+            if should_stop(&state) {
+                break 'outer;
             }
+            handle_copied_data(copy_unkown_data(ud, config))?;
         }
         remove_empty_sub_dirs(&config.paths.input_dir)?;
         if should_stop(&state) {
@@ -121,12 +145,15 @@ fn should_stop(state: &Arc<RwLock<ServiceState>>) -> bool {
 }
 
 ///
-/// Iterates over the files in the given directory and gathers sorting data for DICOM files.
+/// Iterates over the files in the given directory and gathers sorting data.
 ///
 /// This function traverses the specified directory and its subdirectories, examining each
-/// file to determine if it is a DICOM file. If so, it attempts to extract metadata and collects
-/// it as `SortingData`. The function monitors the shared `state` to ensure it halts processing if
-/// the service state is no longer `ServiceState::Running`.
+/// file to determine if it is a DICOM file. It attempts to extract metadata and collects
+/// it as `DicomData`.
+/// Files missing the essential DICOM fields will be logged with a warning and categorized as
+/// unkown data (`SortingData::Unknown`).
+/// The function monitors the shared `state` to ensure it halts processing if the service
+/// state is no longer `ServiceState::Running`.
 ///
 /// # Arguments
 /// * `config` - A `Config` struct providing the input directory path.
@@ -136,15 +163,27 @@ fn should_stop(state: &Arc<RwLock<ServiceState>>) -> bool {
 /// * `Ok(Vec<SortingData>)` - A vector containing `SortingData` for identified DICOM files.
 /// * `Err` - If an error occurs during the directory traversal or file processing.
 ///
-/// # Behavior
-/// * The function stops processing if the service changes to a non-running state.
-/// * Errors during metadata extraction for individual files are logged but do not stop execution.
-///
 /// # Errors
-/// * Returns an error if a directory traversal issue occurs or if it encounters a critical failure
-///   while processing files.
-fn get_sorting_data(config: &Config, state: Arc<RwLock<ServiceState>>) -> Result<Vec<SortingData>> {
-    let mut v = vec![];
+/// This function returns an error if the DICOM file cannot be opened or read. Metadata extraction errors will not cause
+/// a direct error result, but instead result in the file being considered as unknown data.
+///
+/// # Metadata Tags Retrieved
+/// - `PatientID` (DICOM Tag: (0010,0020)): Identifies the patient.
+/// - `PatientBirthDate` (DICOM Tag: (0010,0030)): The patient's date of birth. If missing, this field may attempt to derive a value
+///   from the Patient ID based on predefined rules.
+/// - `SOPInstanceUID` (DICOM Tag: (0008,0018)): A unique identifier for the specific object.
+/// - `Modality` (DICOM Tag: (0008,0060)): Describes the type of equipment used.
+///
+/// # Processing Behavior
+/// If critical metadata is successfully extracted, the file will be categorized as DICOM data (`SortingData::Dicom`).
+/// Files missing essential fields will be logged with a warning and categorized as unknown data (`SortingData::Unknown`).
+///
+fn get_sorting_data(
+    config: &Config,
+    state: Arc<RwLock<ServiceState>>,
+) -> Result<(Vec<DicomData>, Vec<UnknownData>)> {
+    let mut dicom_dataset = vec![];
+    let mut unknown_dataset = vec![];
     // for entry in WalkDir::new(&input_dir).into_iter().filter_map(|r| r.ok()) {
     for entry in WalkDir::new(&config.paths.input_dir) {
         match entry {
@@ -160,12 +199,16 @@ fn get_sorting_data(config: &Config, state: Arc<RwLock<ServiceState>>) -> Result
                     continue;
                 }
                 match extract_dicom_metadata(path) {
-                    Ok(Some(sorting_data)) => {
-                        v.push(sorting_data);
-                    }
-                    Ok(None) => {}
+                    Ok(sorting_data) => match sorting_data {
+                        SortingData::Dicom(data) => {
+                            dicom_dataset.push(data);
+                        }
+                        SortingData::Unknown(data) => {
+                            unknown_dataset.push(data);
+                        }
+                        SortingData::None => {}
+                    },
                     Err(e) => {
-                        // It might not be a DICOM file
                         error!("Failed to process file {}: {}", path.display(), e);
                     }
                 }
@@ -176,7 +219,7 @@ fn get_sorting_data(config: &Config, state: Arc<RwLock<ServiceState>>) -> Result
             }
         }
     }
-    Ok(v)
+    Ok((dicom_dataset, unknown_dataset))
 }
 
 ///
@@ -211,6 +254,10 @@ fn remove_empty_sub_dirs<P: AsRef<Path>>(dir: P) -> Result<()> {
     Ok(())
 }
 
+fn remove_null_chars(s: &str) -> String {
+    s.chars().filter(|c| *c != '\0').collect()
+}
+
 ///
 /// Extracts metadata from a DICOM file, specifically the Patient ID and Date of Birth.
 /// If the birthday doesn't exist and the patient ID is 8 characters or longer, the 3, 4, 5 and 7th character are used as a substitue.
@@ -231,43 +278,33 @@ fn remove_empty_sub_dirs<P: AsRef<Path>>(dir: P) -> Result<()> {
 /// The extracted metadata is represented as a `SortingData` struct containing the following:
 /// * `patient_id` - The Patient ID (DICOM Tag: (0010,0020)) as a string.
 /// * `date_of_birth` - The Date of Birth (DICOM Tag: (0010,0030)) as a string.
-fn extract_dicom_metadata<P: AsRef<Path>>(file_path: P) -> Result<Option<SortingData>> {
-    let dicom_file = open_file(file_path.as_ref())?;
+fn extract_dicom_metadata<P: AsRef<Path>>(file_path: P) -> Result<SortingData> {
+    let dicom_file = open_file(file_path.as_ref());
+    if dicom_file.is_err() {
+        warn!("Failed to extract metadata from file: {}\nThis file will not be treated as a DICOM file in future processing.", file_path.as_ref().display());
+        return Ok(SortingData::Unknown(UnknownData {
+            path: file_path.as_ref().to_path_buf(),
+        }));
+    }
+    let dicom_file = dicom_file?;
 
     let sop_instance_uid = dicom_file
-        .element_by_name("SOPInstanceUID")
-        .ok()
-        .and_then(|elem| match elem.string() {
-            Ok(s) => Some(s.trim().to_string()),
-            Err(e) => {
-                error!("Failed to extract SOP Instance UID: {}", e);
-                None
-            }
-        });
+        .element_by_name_opt("SOPInstanceUID")
+        .map(|elem| elem.map(|elem| remove_null_chars(elem.string().unwrap().trim())));
 
     let modality = dicom_file
-        .element_by_name("Modality")
-        .ok()
-        .and_then(|elem| match elem.string() {
-            Ok(s) => Some(s.trim().to_string()),
-            Err(e) => {
-                error!("Failed to extract Modality: {}", e);
-                None
-            }
-        });
+        .element_by_name_opt("Modality")
+        .map(|elem| elem.map(|elem| remove_null_chars(elem.string().unwrap().trim())));
+
+    // .map(|elem| remove_null_chars(elem.string().unwrap().trim()));
 
     // Extracting Patient ID (Tag: (0010,0020)) and Date of Birth (Tag: (0010,0030)).
     let patient_id = dicom_file
-        .element_by_name("PatientID")
-        .ok()
-        .and_then(|elem| match elem.string() {
-            Ok(s) => Some(s.trim().to_string()),
-            Err(e) => {
-                error!("Failed to extract Patient ID: {}", e);
-                None
-            }
-        });
+        .element_by_name_opt("PatientID")
+        .map(|elem| elem.map(|elem| remove_null_chars(elem.string().unwrap().trim())));
+    // .map(|elem| remove_null_chars(elem.string().unwrap().trim()));
 
+    // Not required by DICOM
     let date_of_birth = dicom_file
         .element_by_name("PatientBirthDate")
         .ok()
@@ -275,26 +312,43 @@ fn extract_dicom_metadata<P: AsRef<Path>>(file_path: P) -> Result<Option<Sorting
             Ok(s) => Some(s.trim().to_string()),
             Err(e) => {
                 error!("Failed to extract Date of Birth: {}.\nTrying to extract part of the patient ID.", e);
-                if let Some(pid) = patient_id.as_ref() {
+                if let Ok(Some(pid)) = patient_id.as_ref() {
                     let t = format!("00{}", &pid[0..6]);
-                    return Some(t);
+                    return Some(remove_null_chars(&t));
                 }
                 None
             }
         });
 
-    if let (Some(sop_instance_uid), Some(modality), Some(pid), Some(dob)) =
-        (sop_instance_uid, modality, patient_id, date_of_birth)
-    {
-        Ok(Some(SortingData {
-            sop_instance_uid,
-            modality,
-            patient_id: pid,
-            date_of_birth: dob,
-            path: file_path.as_ref().to_path_buf(),
-        }))
-    } else {
-        Ok(None)
+    match (sop_instance_uid, patient_id, modality, date_of_birth) {
+        (
+            Ok(Some(sop_instance_uid)),
+            Ok(Some(patient_id)),
+            Ok(Some(modality)),
+            Some(date_of_birth),
+        ) => {
+            debug!(
+                    "Extracted metadata from file: {}.\nSOP Instance UID: {}\nPatient ID: {}\nModality: {}\nDate of Birth: {}",
+                    file_path.as_ref().display(),
+                    sop_instance_uid,
+                    patient_id,
+                    modality,
+                    date_of_birth
+                );
+            Ok(SortingData::Dicom(DicomData {
+                sop_instance_uid: sop_instance_uid.to_string(),
+                modality: modality.to_string(),
+                patient_id: patient_id.to_string(),
+                date_of_birth: date_of_birth.to_string(),
+                path: file_path.as_ref().to_path_buf(),
+            }))
+        }
+        _ => {
+            warn!("Failed to extract metadata from file: {}\nThis file will not be treated as a DICOM file in future processing.", file_path.as_ref().display());
+            Ok(SortingData::Unknown(UnknownData {
+                path: file_path.as_ref().to_path_buf(),
+            }))
+        }
     }
 }
 
@@ -305,7 +359,7 @@ fn extract_dicom_metadata<P: AsRef<Path>>(file_path: P) -> Result<Option<Sorting
 /// * `config` - A `Config` struct providing the output directory path.
 ///
 /// # Returns
-/// * `Ok(MovedData)` - If the file is successfully copied to the output directory.
+/// * `Ok(CopiedData)` - If the file is successfully copied to the output directory.
 /// * `Err` - If any error occurs during the directory creation, file copying, or if the metadata does not adhere to expected formats.
 ///
 /// # Errors
@@ -322,7 +376,7 @@ fn extract_dicom_metadata<P: AsRef<Path>>(file_path: P) -> Result<Option<Sorting
 /// # Assumptions
 /// * `date_of_birth` in `SortingData` is expected to be in the format `YYYYMMDD`. Non-matching formats will result in an error.
 ///
-fn copy_dicom_data(data: SortingData, config: &Config) -> Result<MovedData> {
+fn copy_dicom_data(data: DicomData, config: &Config) -> Result<CopiedData> {
     // Extract the date of birth and patient ID from SortingData
     let dob = &data.date_of_birth;
     let patient_id = &data.patient_id;
@@ -357,7 +411,7 @@ fn copy_dicom_data(data: SortingData, config: &Config) -> Result<MovedData> {
 
     // Construct the final file path in the output directory
     let dest_file_path =
-        output_path.join(format!("{}{}.dcm", &data.modality, &data.sop_instance_uid));
+        output_path.join(format!("{}.{}.dcm", &data.modality, &data.sop_instance_uid));
 
     debug!(
         "Copying file: {} -> {}",
@@ -367,7 +421,50 @@ fn copy_dicom_data(data: SortingData, config: &Config) -> Result<MovedData> {
     // Copy the file to the destination path
     std::fs::copy(source_path, &dest_file_path)?;
 
-    Ok(MovedData {
+    Ok(CopiedData {
+        input: data.path,
+        output: dest_file_path,
+    })
+}
+
+/// Copies an unknown data file to a designated output directory.
+///
+/// # Arguments
+///
+/// * `data` - An `UnknownData` struct containing metadata and the original file path.
+/// * `config` - A `Config` struct providing paths, including the directory for unknown files.
+///
+/// # Returns
+///
+/// * `Ok(CopiedData)` - If the file is successfully copied to the output directory.
+/// * `Err` - If any error occurs during the file copying process.
+///
+/// # Errors
+///
+/// * Returns an error if the source file cannot be copied to the destination unknown directory.
+///
+/// # Behavior
+///
+/// * Copies the file from its original path to the unknown directory path configured in `Config`.
+/// * Logs debug information about the file copy operation, including source and destination paths.
+fn copy_unkown_data(data: UnknownData, config: &Config) -> Result<CopiedData> {
+    // Construct the final file path in the output directory
+    let filename = data.path.file_name();
+    if filename.is_none() {
+        return Err(Error::UnknownFilename);
+    }
+    let filename = filename.unwrap();
+    let dest_file_path = config.paths.unknown_dir.join(filename);
+
+    debug!(
+        "Copying file: {} -> {}",
+        data.path.display(),
+        dest_file_path.display()
+    );
+    // Copy the file to the destination path
+    std::fs::copy(&data.path, &dest_file_path)?;
+
+    Ok(CopiedData {
         input: data.path,
         output: dest_file_path,
     })
@@ -396,7 +493,6 @@ fn is_dir_empty<P: AsRef<Path>>(dir: P) -> bool {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
     use crate::config::Paths;
     use dicom_core::{DataElement, PrimitiveValue};
@@ -477,7 +573,7 @@ mod tests {
         create_test_dicom_file(patient_id, date_of_birth, &input_file)
             .expect("Unable to create test DICOM file.");
 
-        let sorting_data = SortingData {
+        let sorting_data = DicomData {
             sop_instance_uid: "9.3.12.2.1107.5.1.7.130037.30000025021708505036500000024"
                 .to_string(),
             modality: "CT".to_string(),
@@ -487,12 +583,12 @@ mod tests {
         };
 
         let output_file_name = format!(
-            "{}{}.dcm",
+            "{}.{}.dcm",
             &sorting_data.modality, &sorting_data.sop_instance_uid
         );
 
         // Call the function
-        let moved_data = copy_dicom_data(sorting_data, &config).unwrap();
+        let copied_data = copy_dicom_data(sorting_data, &config).unwrap();
 
         // Validate that the file was copied to the correct output directory
         let expected_output_path = config
@@ -502,13 +598,13 @@ mod tests {
             .join(patient_id)
             .join(output_file_name);
         debug!("Expected output path: {}", expected_output_path.display());
-        debug!("Actual output path: {}", moved_data.output.display());
-        assert!(moved_data.output.exists());
+        debug!("Actual output path: {}", copied_data.output.display());
+        assert!(copied_data.output.exists());
         // assert!(expected_output_path.exists());
 
         // Validate the channel message
-        assert_eq!(moved_data.input, input_file);
-        assert_eq!(moved_data.output, expected_output_path);
+        assert_eq!(copied_data.input, input_file);
+        assert_eq!(copied_data.output, expected_output_path);
         std::fs::remove_dir_all(config.paths.input_dir.parent().unwrap()).unwrap()
     }
 
@@ -523,7 +619,7 @@ mod tests {
         create_test_dicom_file(patient_id, invalid_date_of_birth, &input_file)
             .expect("Unable to create test DICOM file.");
 
-        let sorting_data = SortingData {
+        let sorting_data = DicomData {
             sop_instance_uid: "9.3.12.2.1107.5.1.7.130037.30000025021708505036500000024"
                 .to_string(),
             modality: "CT".to_string(),
@@ -551,7 +647,7 @@ mod tests {
         let date_of_birth = "19850615";
         let input_file = config.paths.input_dir.join("test.dcm");
 
-        let sorting_data = SortingData {
+        let sorting_data = DicomData {
             sop_instance_uid: "9.3.12.2.1107.5.1.7.130037.30000025021708505036500000024"
                 .to_string(),
             modality: "CT".to_string(),


### PR DESCRIPTION
### Summary

This pull request introduces several critical improvements:

- **Retry Mechanisms**: Adds configurable retry logic for file operations to handle `ResourceBusy` errors effectively. New parameters (`io_timeout_millisec`, `copy_attempts`, `remove_attempts`, `mtime_delay_secs`) allow fine-grained control over retries.
- **State Management**: Refactors the existing `RwLock` state management approach, replacing it with more efficient `mpsc` channels.
- **Configuration Enhancements**: Implements `TryFrom<Cli>` for streamlined configuration creation, with robust error handling and restructuring of function dependencies to incorporate a `Config` struct.

### Changes Made

- Retry logic for file operations with configurable timeouts and attempts (`copy_with_retry_on_busy`).
- Enhanced state management leveraging `mpsc` channels for better scalability and reliability.
- Clean integration of CLI configuration with backward compatibility for configuration files.
- Updated `filetime` dependency for handling file modification times.
- Improved error handling and logging mechanisms.
