### PR TITLE
Remove unused dependencies and update versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["dcm_ls", "dcm_cp", "mpc_checks_cleaner", "one_way_sync", "dcm_file_sort_service"]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 #name = "rad-tools"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 authors = ["Tom Vercauteren"]
 
 [workspace.dependencies]
-thiserror = "1"
+thiserror = "2"
 anyhow = "1"
 quick-xml = "0.37"
 base64 = "0.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,6 @@ authors = ["Tom Vercauteren"]
 [workspace.dependencies]
 thiserror = "2"
 anyhow = "1"
-quick-xml = "0.37"
-base64 = "0.22"
-ndarray = "0.16"
 clap = { version = "4", features = ["derive"] }
 dicom-core = "0.8"
 dicom-object = "0.8"
@@ -21,16 +18,11 @@ dicom-dictionary-std = "0.8.0"
 dicom-encoding = "0.8"
 dicom-transfer-syntax-registry = "0.8"
 walkdir = "2"
-tokio = { version = "1", features = ["full"] }
-crossterm = "0.28"
-ratatui = { version = "0.29", features = ["default"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 comfy-table = "7"
 rayon = "1"
 chrono = "0.4"
-async-std = { version = "1", features = ["attributes"] }
-relative-path = "1"
 pathdiff = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_with = "3"


### PR DESCRIPTION
### Description

- Removed unused dependencies: `quick-xml`, `base64`, `ndarray`, `tokio`, `crossterm`, `ratatui`, `async-std`, and `relative-path` from `Cargo.toml`.
- Bumped `thiserror` crate to version 2.
- Updated workspace resolver to version 3. 

These changes streamline the project by removing unnecessary packages and ensuring compatibility with updated versions.