### PR TITLE
Refactor `grep` for better DICOM element handling

### DIFF
--- a/dcm_grep/src/lib.rs
+++ b/dcm_grep/src/lib.rs
@@ -2,6 +2,6 @@ mod error;
 mod grep;
 mod pattern;
 
-pub use grep::{GrepResult, grep};
+pub use grep::{GrepResult, element_value_to_string, grep};
 
 pub use error::Error;

--- a/dcm_grep/src/main.rs
+++ b/dcm_grep/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use rad_tools_dcm_grep::grep;
+use rad_tools_dcm_grep::{element_value_to_string, grep};
 use std::io::{self, BufRead};
 
 /// Extract the values of one or more (nested) DICOM tags.
@@ -91,11 +91,15 @@ fn main() {
 
     if args.show_path {
         for result in results {
-            println!("{}: {}", result.path, result.value);
+            println!(
+                "{}: {}",
+                result.path,
+                element_value_to_string(result.element)
+            );
         }
     } else {
         for result in results {
-            println!("{}", result.value);
+            println!("{}", element_value_to_string(result.element));
         }
     }
 }


### PR DESCRIPTION
- Refactored `grep` interface to return references to DICOM elements in results instead of raw Strings.
- Introduced the `element_value_to_string` helper function to standardize value conversions.
- Updated related unit tests and the main function to integrate the new helper function seamlessly.